### PR TITLE
Improve performance with batched MCP writes and custom PWM setting function

### DIFF
--- a/BamBotMotorDriver.cpp
+++ b/BamBotMotorDriver.cpp
@@ -2,16 +2,76 @@
 #include "BamBotMotorDriver.h"
 #include <Adafruit_MCP23008.h>
 
+/*
+	Code here from https://github.com/espressif/arduino-esp32/blob/600f4c4130f2411e8ff33396d0ef40a7ec257cd6/cores/esp32/esp32-hal-ledc.c
+*/
+
+// Section copyright:
+//
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "esp32-hal.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "rom/ets_sys.h"
+#include "esp32-hal-matrix.h"
+#include "soc/dport_reg.h"
+#include "soc/ledc_reg.h"
+#include "soc/ledc_struct.h"
+#define LEDC_CHAN(g,c) LEDC.channel_group[(g)].channel[(c)]
+#define LEDC_TIMER(g,t) LEDC.timer_group[(g)].timer[(t)]
+static void aWrite(uint8_t chan, uint32_t duty)
+{
+    if(chan > 15) return;
+    uint8_t group=(chan/8), channel=(chan%8);
+    //LEDC_MUTEX_LOCK();
+    LEDC_CHAN(group, channel).duty.duty = duty << 4;//25 bit (21.4)
+    if(duty) {
+        LEDC_CHAN(group, channel).conf0.sig_out_en = 1;//This is the output enable control bit for channel
+        LEDC_CHAN(group, channel).conf1.duty_start = 1;//When duty_num duty_cycle and duty_scale has been configured. these register won't take effect until set duty_start. this bit is automatically cleared by hardware.
+        if(group) {
+            LEDC_CHAN(group, channel).conf0.val |= BIT(4);
+        } else {
+            LEDC_CHAN(group, channel).conf0.clk_en = 1;
+        }
+    } else {
+        LEDC_CHAN(group, channel).conf0.sig_out_en = 0;//This is the output enable control bit for channel
+        LEDC_CHAN(group, channel).conf1.duty_start = 0;//When duty_num duty_cycle and duty_scale has been configured. these register won't take effect until set duty_start. this bit is automatically cleared by hardware.
+        if(group) {
+            LEDC_CHAN(group, channel).conf0.val &= ~BIT(4);
+        } else {
+            LEDC_CHAN(group, channel).conf0.clk_en = 0;
+        }
+    }
+    //LEDC_MUTEX_UNLOCK();
+}
+
+/*
+	End section.
+*/
 
 /*******************
 Motor Initialization
 ********************/
 
-//initialize the motor driver assuming all four pins are connected 
+//initialize the motor driver assuming all four pins are connected
 //directly to the M5Stack
-void BamBotMotorDriver::init(byte M1Pwm, 
-										byte M1Dir, 
-										byte M2Pwm, 
+void BamBotMotorDriver::init(byte M1Pwm,
+										byte M1Dir,
+										byte M2Pwm,
 										byte M2Dir)
 {
 	_USING_MCP = false;
@@ -21,7 +81,7 @@ void BamBotMotorDriver::init(byte M1Pwm,
 	_M1Dir = M1Dir;
 	_M2Pwm = M2Pwm;
 	_M2Dir = M2Dir;
-	
+
 	_flipM1 = false;
 	_flipM2 = false;
 
@@ -42,7 +102,7 @@ void BamBotMotorDriver::init(byte M1Pwm,
   digitalWrite(_M2Dir, LOW);
   pinMode(_M2Dir, OUTPUT);
   digitalWrite(_M2Dir, LOW);
-  
+
   //Initialize the PWM channels
   //use the ESP32 function ledc to output PWM
   ledcSetup(M1CHN, PWM_FREQUENCY, PWM_PRECISION);
@@ -53,9 +113,9 @@ void BamBotMotorDriver::init(byte M1Pwm,
 
 //initialize the motor driver assuming the direction pins are connected to the MCP
 void BamBotMotorDriver::init(Adafruit_MCP23008 mcp,
-										byte M1Pwm, 
-										byte M1Dir, 
-										byte M2Pwm, 
+										byte M1Pwm,
+										byte M1Dir,
+										byte M2Pwm,
 										byte M2Dir)
 {
 	_USING_MCP = true;
@@ -66,7 +126,7 @@ void BamBotMotorDriver::init(Adafruit_MCP23008 mcp,
 	_M1Dir = M1Dir;
 	_M2Pwm = M2Pwm;
 	_M2Dir = M2Dir;
-	
+
 	_flipM1 = false;
 	_flipM2 = false;
 
@@ -81,11 +141,15 @@ void BamBotMotorDriver::init(Adafruit_MCP23008 mcp,
   digitalWrite(_M2Pwm, LOW);
   pinMode(_M2Pwm, OUTPUT);
   digitalWrite(_M2Pwm, LOW);
-  
+
   //initialize the direction pins on the MCP
   _MCP.pinMode(_M1Dir, OUTPUT);
   _MCP.pinMode(_M2Dir, OUTPUT);
-  
+
+#ifdef MCP_ASYNC
+  _MCP.setAsync(true);
+#endif
+
   //Initialize the PWM channels
   //use the ESP32 function ledc to output PWM
   ledcSetup(M1CHN, PWM_FREQUENCY, PWM_PRECISION);
@@ -99,8 +163,11 @@ Motor Drive
 ***********/
 
 // speed should be a number between -400 and 400
-void BamBotMotorDriver::setM1Speed(int speed)
-{
+#ifdef MCP_ASYNC
+void BamBotMotorDriver::setM1Speed(int speed, bool sync) {
+#else
+void BamBotMotorDriver::setM1Speed(int speed) {
+#endif
 	//set reverse to true if one, but not both of these conditions are true
 	bool reverse = (!(speed < 0) != !_flipM1);
 
@@ -119,11 +186,18 @@ void BamBotMotorDriver::setM1Speed(int speed)
 	} else {
 		digitalWrite(_M1Dir, reverse);
 	}
+
+#ifdef MCP_ASYNC
+	if(sync) _MCP.flush();
+#endif
 }
 
 // speed should be a number between -400 and 400
-void BamBotMotorDriver::setM2Speed(int speed)
-{
+#ifdef MCP_ASYNC
+void BamBotMotorDriver::setM2Speed(int speed, bool sync) {
+#else
+void BamBotMotorDriver::setM2Speed(int speed) {
+#endif
 	//set reverse to true if one, but not both of these conditions are true
 	bool reverse = (!(speed < 0) != !_flipM2);
 
@@ -135,20 +209,40 @@ void BamBotMotorDriver::setM2Speed(int speed)
 
 	//set the speed
 	_setPWM(M2CHN, speed);
-	
+
 	//set the direction
 	if (_USING_MCP) {
 		_MCP.digitalWrite(_M2Dir, reverse);
 	} else {
 		digitalWrite(_M2Dir, reverse);
 	}
+
+#ifdef MCP_ASYNC
+	if(sync) _MCP.flush();
+#endif
 }
+
+#ifdef MCP_ASYNC
+void BamBotMotorDriver::setM1Speed(int speed) {
+	BamBotMotorDriver::setM1Speed(speed, true);
+}
+
+void BamBotMotorDriver::setM2Speed(int speed) {
+	BamBotMotorDriver::setM2Speed(speed, true);
+}
+#endif
 
 // set speed for both motors
 // speed should be a number between -400 and 400
 void BamBotMotorDriver::setSpeeds(int m1Speed, int m2Speed){
+#ifdef MCP_ASYNC
+  setM1Speed(m1Speed, false);
+  setM2Speed(m2Speed, false);
+  _MCP.flush();
+#else
   setM1Speed(m1Speed);
   setM2Speed(m2Speed);
+#endif
 }
 
 //Set the reverse flag for the motors
@@ -165,14 +259,14 @@ void BamBotMotorDriver::flipM2(bool flip)
 //Private PWM function
 //Set the PWM output using the ledcWrite function
 void BamBotMotorDriver::_setPWM(uint8_t channel, uint32_t value) {
-	
+
 	uint32_t duty;
 	if (value == 0) {
 		duty = 0;
 	} else {
 		duty = (8191 - DEADBAND)*value/400 + DEADBAND;
 	}
-	ledcWrite(channel, duty);
+	aWrite(channel, duty);
 }
 
 
@@ -200,19 +294,19 @@ void BamBotMotorDriver::attachEncoders(byte pin1A, byte pin1B, byte pin2A, byte 
 	_enc1PinB = pin1B;
 	_enc2PinA = pin2A;
 	_enc2PinB = pin2B;
-	
+
 	//Initialize the position and state variables
 	_position1 = 0;
 	_position2 = 0;
 	_state1 = 0;
 	_state2 = 0;
-	
+
 	//Initialize the encoder pins
 	pinMode(_enc1PinA, INPUT_PULLUP);
 	pinMode(_enc1PinB, INPUT_PULLUP);
 	pinMode(_enc2PinA, INPUT_PULLUP);
 	pinMode(_enc2PinB, INPUT_PULLUP);
-	
+
 	//Attach interrupts to moniter when the pins change state
 	attachInterrupt(digitalPinToInterrupt(_enc1PinA), _updatePosition, CHANGE);
 	attachInterrupt(digitalPinToInterrupt(_enc1PinB), _updatePosition, CHANGE);
@@ -250,16 +344,16 @@ void BamBotMotorDriver::motor2ResetPosition() {
 //state for the next call.
 void BamBotMotorDriver::_updatePosition() {
 	portENTER_CRITICAL_ISR(&_mux);
-	
+
 	int s;
-	
-	
+
+
 	//Update encoder 1
 	s = _state1 & 3;
-	
+
 	if (digitalRead(_enc1PinA)) s |= 4;
 	if (digitalRead(_enc1PinB)) s |= 8;
-	
+
 	switch (s) {
 		case 0: case 5: case 10: case 15:	//No movement
 			break;
@@ -276,16 +370,16 @@ void BamBotMotorDriver::_updatePosition() {
 			_position1 -= 2;
 			break;
 	}
-	
+
 	_state1 = (s >> 2);
-	
-	
+
+
 	//Update encoder 2
 	s = _state2 & 3;
 
 	if (digitalRead(_enc2PinA)) s |= 4;
 	if (digitalRead(_enc2PinB)) s |= 8;
-	
+
 	switch (s) {
 		case 0: case 5: case 10: case 15:	//No movement
 			break;
@@ -305,12 +399,6 @@ void BamBotMotorDriver::_updatePosition() {
 
 	_state2 = (s >> 2);
 
-	
+
 	portEXIT_CRITICAL_ISR(&_mux);
 }
-
-
-
-
-
-

--- a/BamBotMotorDriver.h
+++ b/BamBotMotorDriver.h
@@ -13,22 +13,26 @@
 
 class BamBotMotorDriver
 {
-	public:	  
+	public:
 		void init(byte M1Pwm = 3,
-						byte M1Dir = 1, 
-						byte M2Pwm = 17, 
+						byte M1Dir = 1,
+						byte M2Pwm = 17,
 						byte M2Dir = 16);
 		void init(Adafruit_MCP23008 mcp,
 						byte M1Pwm = 3,
-						byte M1Dir = 7, 
-						byte M2Pwm = 1, 
+						byte M1Dir = 7,
+						byte M2Pwm = 1,
 						byte M2Dir = 6);
+#ifdef MCP_ASYNC
+		void setM1Speed(int speed, bool sync);
+		void setM2Speed(int speed, bool sync);
+#endif
 		void setM1Speed(int speed);
 		void setM2Speed(int speed);
 		void setSpeeds(int m1Speed, int m2Speed);
 		void flipM1(boolean flip);
 		void flipM2(boolean flip);
-		 
+
 		 //Encoder functions
 		void attachEncoders(byte pin1A, byte pin1B, byte pin2A, byte pin2B);
 		int motor1Position();

--- a/BamBotMotorDriver.h
+++ b/BamBotMotorDriver.h
@@ -23,10 +23,6 @@ class BamBotMotorDriver
 						byte M1Dir = 7,
 						byte M2Pwm = 1,
 						byte M2Dir = 6);
-#ifdef MCP_ASYNC
-		void setM1Speed(int speed, bool sync);
-		void setM2Speed(int speed, bool sync);
-#endif
 		void setM1Speed(int speed);
 		void setM2Speed(int speed);
 		void setSpeeds(int m1Speed, int m2Speed);
@@ -41,6 +37,10 @@ class BamBotMotorDriver
 		void motor2ResetPosition();
 
 	private:
+#ifdef MCP_ASYNC
+		void setM1Speed(int speed, bool sync);
+		void setM2Speed(int speed, bool sync);
+#endif
 		void _setPWM(uint8_t channel, uint32_t value);
 		bool _USING_MCP;
 		Adafruit_MCP23008 _MCP;


### PR DESCRIPTION
The batched MCP requires [my fork of the MCP lib](https://github.com/jadr2ddude/Adafruit-MCP23008-library), but it will automatically be deactivated if the Adafruit MCP lib is used. Also #3 is fixed by using a custom PWM function which removes unnecessary PWM mutex access.